### PR TITLE
Fixed BASE_DN isn't properly set when using subdomains.

### DIFF
--- a/install/assets/custom-scripts/001-install-fusiondirectory.sh
+++ b/install/assets/custom-scripts/001-install-fusiondirectory.sh
@@ -35,9 +35,10 @@ if [ ! -e ${FUSIONDIRECTORY_INSTALLED} ]; then
 	for elem in "${domain_elems[@]}" ; do
 	    if [ "x${SUFFIX}" = x ] ; then
 	        SUFFIX="dc=${elem}"
+		BASE_DN="${SUFFIX}"
 	        ROOT="${elem}"
 	    else
-	        BASE_DN="${SUFFIX},dc=${elem}"
+	        BASE_DN="${BASE_DN},dc=${elem}"
 	    fi
 	done
 


### PR DESCRIPTION
Initialized BASE_DN to SUFFIX and concat BASE_DN with itself + current domain element.

This commit fix issue #8


PS. I didn't have tools right now to test it, but it should work. 
I'll do it when I come home in ~10h.