### PR TITLE
update the pinning so as to allow sasl dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/tiredofit/openldap:2.6-7.6.8
+FROM docker.io/tiredofit/openldap:2.6-7.6.9
 LABEL maintainer="Dave Conroy (github.com/tiredofit)"
 
 ARG FUSIONDIRECTORY_VERSION


### PR DESCRIPTION
(not tested yet)